### PR TITLE
Update target-lexicon to 0.12.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ scroll = "0.11"
 log = "0.4"
 indexmap = "1"
 string-interner = "0.12"
-target-lexicon = "0.12"
+target-lexicon = "0.12.2"
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -47,6 +47,7 @@ impl From<Architecture> for MachineTag {
             X86_32(_) => EM_386,
             Aarch64(_) => EM_AARCH64,
             Arm(_) => EM_ARM,
+            Bpfel | Bpfeb => EM_BPF,
             Mips32(_) | Mips64(_) => EM_MIPS,
             Powerpc => EM_PPC,
             Powerpc64 | Powerpc64le => EM_PPC64,


### PR DESCRIPTION
These targets are for big-endian and little-endian versions of the Linux bpf subsystem.